### PR TITLE
Update to Rust 2021 edition, add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,15 @@ description = "A simple CSS 2 parser and selector."
 repository = "https://github.com/RazrFalcon/simplecss"
 keywords = ["css", "parser", "selector"]
 categories = ["parser-implementations"]
-edition = "2018"
+edition = "2021"
 exclude = ["testing-tools/**"]
 
+[features]
+default = ["std"]
+std = ["log/std"]
+
 [dependencies]
-log = "0.4.8"
+log = { version = "0.4.8", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.6", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,14 @@ Since it's very simple we will start with limitations:
 */
 
 #![doc(html_root_url = "https://docs.rs/simplecss/0.2.1")]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
-use std::fmt;
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::fmt;
 
 use log::warn;
 
@@ -126,6 +130,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 /// A position in text.

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1,4 +1,5 @@
-use std::fmt;
+use alloc::{vec, vec::Vec};
+use core::fmt;
 
 use log::warn;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,4 +1,4 @@
-use std::str;
+use core::str;
 
 use crate::{Error, TextPos};
 
@@ -284,7 +284,7 @@ impl<'a> Stream<'a> {
     #[inline(never)]
     pub fn gen_text_pos_from(&self, pos: usize) -> TextPos {
         let mut s = *self;
-        s.pos = std::cmp::min(pos, self.text.len());
+        s.pos = core::cmp::min(pos, self.text.len());
         s.gen_text_pos()
     }
 


### PR DESCRIPTION
The update to 2021 stops the dev dependencies from interfering with the features enabled in `log`, breaking `no_std` builds within the repository.