### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,49 @@
-# Change Log
-All notable changes to this project will be documented in this file.
+# Changelog
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/1.0.0/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+The latest published SimpleCSS release is [0.2.1](#021-2021-07-20) which was released on 2021-07-20.
+You can find its changes [documented below](#021-2021-07-20).
 
 ## [Unreleased]
 
 This release has an [MSRV][] of 1.65.
 
-## [0.2.1] - 2021-07-20
-- Add rules sorting by specificity. Thanks to [@baskerville](https://github.com/baskerville)
+This is the first release under the stewardship of [Linebender][], who is now responsible for maintenance
+of this crate. Many thanks to Yevhenii Reizner for the years of hard work that he has poured into this and
+other crates.
 
-## [0.2.0] - 2019-08-17
+## Added
+
+- Support for `no_std`. ([#17][] by [@waywardmonkeys][])
+
+## [0.2.1][] (2021-07-20)
+
+- Add rules sorting by specificity. ([#7][] by [@baskerville][])
+
+## [0.2.0][] (2019-08-17)
+
 - A complete rewrite.
 
-## 0.1.0 - 2017-01-14
+## 0.1.0 (2017-01-14)
+
 - Initial release.
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv
+[Linebender]: https://github.com/linebender
+
+[#7]: https://github.com/linebender/simplecss/pull/7
+[#17]: https://github.com/linebender/simplecss/pull/17
+
+[@baskerville]: https://github.com/baskerville
+[@waywardmonkeys]: https://github.com/waywardmonkeys
 
 [Unreleased]: https://github.com/RazrFalcon/simplecss/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/RazrFalcon/simplecss/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/RazrFalcon/simplecss/compare/v0.1.0...v0.2.0
-
-[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,8 @@ You can find its changes [documented below](#021-2021-07-20).
 
 This release has an [MSRV][] of 1.65.
 
-This is the first release under the stewardship of [Linebender][], who is now responsible for maintenance
-of this crate. Many thanks to Yevhenii Reizner for the years of hard work that he has poured into this and
-other crates.
+This is the first release under the stewardship of [Linebender][], who is now responsible for maintenance of this crate.
+Many thanks to Yevhenii Reizner for the years of hard work that he has poured into this and other crates.
 
 ## Added
 


### PR DESCRIPTION
This brings it in line with the other Linebender changelogs and adds an entry for the `no_std` change.